### PR TITLE
Bump remote_syslog to v0.18+ 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ deploy:
 import: package
 	-$(GRAVITY) app delete --ops-url=$(OPS_URL) $(REPOSITORY)/$(NAME):$(VERSION) \
 		--force --insecure
-	$(GRAVITY) app import --debug --insecure --vendor \
+	$(GRAVITY) app import --insecure --vendor \
 		--ops-url=$(OPS_URL) \
 		$(UPDATE_IMAGE_OPTS) \
 		$(UPDATE_METADATA_OPTS) \

--- a/cmd/wstail/matcher.go
+++ b/cmd/wstail/matcher.go
@@ -38,7 +38,13 @@ func buildMatcher(filter filter) string {
 	for _, podName := range pods {
 		podMatchers = append(podMatchers, fmt.Sprintf(`%v_%v_%v`, podName, podNamespace, containerFileMatcher))
 	}
-	return matchPrefix + matchWhitespace + "(" + strings.Join(podMatchers, "|") + ")"
+	capture := []string{"(" + strings.Join(podMatchers, "|") + ")"}
+	// In case of a file filter, also consider files outside of k8s context
+	for _, file := range filter.files {
+		capture = append(capture, file)
+	}
+
+	return matchPrefix + matchWhitespace + strings.Join(capture, "|")
 }
 
 // Matchers

--- a/cmd/wstail/matcher_test.go
+++ b/cmd/wstail/matcher_test.go
@@ -25,6 +25,13 @@ func (s *S) TestBuildsMatcher(c *C) {
 			expected: matchPrefix + matchWhitespace + `(qux_[^_]+_(foo-)|baz_[^_]+_(foo-))`,
 			comment:  "replicates containers for each pod",
 		},
+		{
+			filter: filter{
+				files: []string{"foo-bar.log"},
+			},
+			expected: matchPrefix + matchWhitespace + `([^_]+_[^_]+_([a-zA-Z\0-9-]+-foo-bar.log))|foo-bar.log`,
+			comment:  "matches a file either in pod/container context or alone",
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/cmd/wstail/tail.go
+++ b/cmd/wstail/tail.go
@@ -75,7 +75,7 @@ func tailer(ws *websocket.Conn, filter filter) {
 					if truncAt > maxDumpLen {
 						truncAt = maxDumpLen
 					}
-					log.Infof("failed to unmarshal `%v`: %v", message[:truncAt], err)
+					log.Infof("failed to unmarshal `%v...`: %v", message[:truncAt], err)
 					// Use the message as-is
 				}
 			}

--- a/cmd/wstail/tail.go
+++ b/cmd/wstail/tail.go
@@ -40,7 +40,7 @@ func tailer(ws *websocket.Conn, filter filter) {
 		return
 	}
 	files := append(rotated, "-f", filePath)
-	args := append([]string{"-c", "+1"}, files...)
+	args := append([]string{"-n", "+1"}, files...)
 	tailCmd := exec.Command("tail", args...)
 	commands := []*exec.Cmd{tailCmd}
 	if matcher != "" {
@@ -91,6 +91,9 @@ func tailer(ws *websocket.Conn, filter filter) {
 				log.Infof("failed to convert to JSON: %v", err)
 			} else {
 				errDisconnected = ws.WriteMessage(websocket.TextMessage, data)
+				if errDisconnected != nil {
+					log.Infof("break read loop: %v", errDisconnected)
+				}
 			}
 		}
 	}

--- a/cmd/wstail/tail.go
+++ b/cmd/wstail/tail.go
@@ -37,6 +37,7 @@ func tailer(ws *websocket.Conn, filter filter) {
 	rotated, err := collectRotatedMessages()
 	if err != nil {
 		log.Errorf("failed to read a list of rotated log files: %v", err)
+		return
 	}
 	files := append(rotated, "-f", filePath)
 	args := append([]string{"-c", "+1"}, files...)

--- a/images/buildbox.mk
+++ b/images/buildbox.mk
@@ -17,7 +17,7 @@ override BUILDDIR=$(ASSETS)/build
 # Configuration by convention: use TARGET as a directory name
 BINARIES=$(BUILDDIR)/$(TARGET)
 
-BBOX := quay.io/gravitational/debian-venti:go1.7-jessie
+BBOX := quay.io/gravitational/debian-venti:go1.7.1-jessie
 
 all: prepare $(BINARIES)
 

--- a/images/forwarder/Dockerfile
+++ b/images/forwarder/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/gravitational/debian-grande:0.0.1
 
-ADD ./remote_syslog /usr/local/bin/remote_syslog
+ADD ./build/remote_syslog /usr/local/bin/remote_syslog
 ADD ./remote_syslog.yml /etc/remote_syslog.yml
 
 RUN chmod +x /usr/local/bin/remote_syslog

--- a/images/forwarder/Makefile
+++ b/images/forwarder/Makefile
@@ -1,4 +1,7 @@
-override VERSION:=v0.17
+# We need a version >v0.18 as it contains
+# https://github.com/papertrail/remote_syslog2/pull/174
+# in which remote_syslog2 forwards new files entirely
+override VERSION:=9151f7e8eab2d69666aa43e6aeb56fc3aa4065fc
 GOFLAGS=-installsuffix cgo --ldflags '-w -s' -a
 GOBUILDPREFIX=GOOS=linux GOARCH=amd64 CGO_ENABLED=0
 BASEREPO:=github.com/papertrail
@@ -6,16 +9,17 @@ REPO:=$(BASEREPO)/remote_syslog2
 BASEDIR:=$(GOPATH)/src/$(BASEREPO)
 REPODIR:=$(BASEDIR)/remote_syslog2
 OUT=/targetdir/remote_syslog
+GOLDFLAGS="-X main.Version=$(VERSION)"
 
 .PHONY: all
 all: $(OUT)
 
 $(OUT): /assets/Makefile
 	@echo "\n---> Building $@\n"
-	GOBIN=$$GOROOT/bin go get github.com/tools/godep
 	mkdir -p $(BASEDIR)
-	cd $(BASEDIR) && git clone https://$(REPO) -b $(VERSION) --depth=1
-	cd $(REPODIR) && $(GOBUILDPREFIX) godep go build $(GOFLAGS) -o $@ .
+	cd $(BASEDIR) && git clone https://$(REPO)
+	cd $(REPODIR) && git checkout $(VERSION)
+	cd $(REPODIR) && $(GOBUILDPREFIX) go build $(GOFLAGS) -ldflags=$(GOLDFLAGS) -o $@ .
 
 .PHONY: clean
 clean:

--- a/images/forwarder/remote_syslog.yml
+++ b/images/forwarder/remote_syslog.yml
@@ -1,6 +1,7 @@
 files:
-  - /var/log/gravity/*.log
+  - /var/log/gravity/**/*.log
   - /var/log/containers/*.log
+  - /var/lib/gravity/site/**/*.log
 destination:
   host: log-collector.kube-system.svc.cluster.local
   port: 514

--- a/resources/resources.yaml
+++ b/resources/resources.yaml
@@ -94,6 +94,30 @@ spec:
               mountPath: /var/log/containers
             - name: extdockercontainers
               mountPath: /ext/docker/containers
+          livenessProbe:
+            httpGet:
+              path: /readyz
+              port: 8082
+              scheme: HTTP
+            initialDelaySeconds: 10
+            timeoutSeconds: 60
+        - name: healthz
+          image: gcr.io/google_containers/exechealthz-amd64:1.0
+          resources:
+            # keep request = limit to keep this container in guaranteed class
+            limits:
+              cpu: 10m
+              memory: 20Mi
+            requests:
+              cpu: 10m
+              memory: 20Mi
+          args:
+            - -cmd=nslookup log-collector.kube-system.svc.cluster.local 127.0.0.1:10053 | tail -n1 | awk '{printf "%s:514", $3}' | xargs -0 -I addr timeout -t 30 telnet addr
+            - -port=8082
+            - -quiet
+          ports:
+            - containerPort: 8082
+              protocol: TCP
       volumes:
         - name: gravitylog
           hostPath:

--- a/resources/resources.yaml
+++ b/resources/resources.yaml
@@ -100,7 +100,7 @@ spec:
               port: 8082
               scheme: HTTP
             initialDelaySeconds: 10
-            timeoutSeconds: 60
+            timeoutSeconds: 30
         - name: healthz
           image: gcr.io/google_containers/exechealthz-amd64:1.0
           resources:
@@ -112,7 +112,7 @@ spec:
               cpu: 10m
               memory: 20Mi
           args:
-            - -cmd=nslookup log-collector.kube-system.svc.cluster.local 127.0.0.1:10053 | tail -n1 | awk '{printf "%s:514", $3}' | xargs -0 -I addr timeout -t 30 telnet addr
+            - -cmd=nslookup log-collector.kube-system.svc.cluster.local | tail -n1 | awk '{printf "%s:514", $3}' | xargs -0 -I addr timeout -t 30 telnet addr
             - -port=8082
             - -quiet
           ports:


### PR DESCRIPTION
- (a few commits after v0.18) to include a change when remote_syslog2 forwards new files entirely (as opposed to tailing them). This is necessary for static logs as these need to be forwards in their entirety.
- Bumping above also discovered the [issue](https://github.com/golang/go/issues/16739) with go1.7 net module ignoring `.local` suffixed domain names from DNS lookup and updated to go1.7.1 where this has been fixed.
- Tweaked matcher w.r.t to files to also handle files outside of k8s context - as the case is with external logs not from a container
- Removed querying the log history - simply using `tail -n +1` will start tailing from the beginning
- `tail` will also output rotated log files (if any) prior to tailing the active one
