### PR TITLE
Tune the logging behavior / switch to a forked remote_syslog (for the time being)

### DIFF
--- a/cmd/wstail/query.go
+++ b/cmd/wstail/query.go
@@ -146,6 +146,13 @@ func (r *parser) error(pos scanner.Position, message string) {
 	r.errors = append(r.errors, trace.Errorf("%v: %v", pos, message))
 }
 
+func (r filter) isEmpty() bool {
+	return len(r.containers) == 0 &&
+		len(r.pods) == 0 &&
+		len(r.files) == 0 &&
+		r.freeText == ""
+}
+
 func tokenStrings(tokens []rune) string {
 	var output bytes.Buffer
 	for i, token := range tokens {

--- a/images/forwarder/Makefile
+++ b/images/forwarder/Makefile
@@ -1,12 +1,13 @@
 # We need a version >v0.18 as it contains
 # https://github.com/papertrail/remote_syslog2/pull/174
 # in which remote_syslog2 forwards new files entirely
-override VERSION:=9151f7e8eab2d69666aa43e6aeb56fc3aa4065fc
+override VERSION:=415704611b83856f20431fa495144a011651b6a6
 GOFLAGS=-installsuffix cgo --ldflags '-w -s' -a
 GOBUILDPREFIX=GOOS=linux GOARCH=amd64 CGO_ENABLED=0
-BASEREPO:=github.com/papertrail
+BASEREPO:=github.com/gravitational
+ORIGREPO:=github.com/papertrail
 REPO:=$(BASEREPO)/remote_syslog2
-BASEDIR:=$(GOPATH)/src/$(BASEREPO)
+BASEDIR:=$(GOPATH)/src/$(ORIGREPO)
 REPODIR:=$(BASEDIR)/remote_syslog2
 OUT=/targetdir/remote_syslog
 GOLDFLAGS="-X main.Version=$(VERSION)"
@@ -18,8 +19,8 @@ $(OUT): /assets/Makefile
 	@echo "\n---> Building $@\n"
 	mkdir -p $(BASEDIR)
 	cd $(BASEDIR) && git clone https://$(REPO)
-	cd $(REPODIR) && git checkout $(VERSION)
-	cd $(REPODIR) && $(GOBUILDPREFIX) go build $(GOFLAGS) -ldflags=$(GOLDFLAGS) -o $@ .
+	cd $(REPODIR) && git checkout $(VERSION) && \
+		$(GOBUILDPREFIX) go build $(GOFLAGS) -ldflags=$(GOLDFLAGS) -o $@ .
 
 .PHONY: clean
 clean:

--- a/resources/resources.yaml
+++ b/resources/resources.yaml
@@ -94,30 +94,6 @@ spec:
               mountPath: /var/log/containers
             - name: extdockercontainers
               mountPath: /ext/docker/containers
-          livenessProbe:
-            httpGet:
-              path: /readyz
-              port: 8082
-              scheme: HTTP
-            initialDelaySeconds: 10
-            timeoutSeconds: 30
-        - name: healthz
-          image: gcr.io/google_containers/exechealthz-amd64:1.0
-          resources:
-            # keep request = limit to keep this container in guaranteed class
-            limits:
-              cpu: 10m
-              memory: 20Mi
-            requests:
-              cpu: 10m
-              memory: 20Mi
-          args:
-            - -cmd=nslookup log-collector.kube-system.svc.cluster.local | tail -n1 | awk '{printf "%s:514", $3}' | xargs -0 -I addr timeout -t 30 telnet addr
-            - -port=8082
-            - -quiet
-          ports:
-            - containerPort: 8082
-              protocol: TCP
       volumes:
         - name: gravitylog
           hostPath:


### PR DESCRIPTION
- `tail`: do not send the whole aggregated log file on an empty filter query - limit this to some arbitrary number of last lines (100 as used previously for history).
- `forwarder`: switch to a fork of remote_syslog with a fixed problem of initial failure to connect leading to forwarder being unable to subsequently reconnect. This also removes the need for the `livenessProbe`.

Fixes https://github.com/gravitational/gravity/issues/1111 and https://github.com/gravitational/gravity/issues/1119

This PR requires that this be merged as well: https://github.com/papertrail/remote_syslog2/pull/175

A small caveat: if the forwarder starts (i.e. initially successfully connects) **after** any log files have been already placed (i.e. install log -> right after the installation and the forwarder is flaking), they will not be forwarded as new (i.e. in their entirety) - a more complete solution (to remote_syslog2) would be to always start and try to rebuild the top-level connection.
I think I want to implement this and see how that works.
