### PR TITLE
Dmitri/limit history

### DIFF
--- a/cmd/wstail/matcher.go
+++ b/cmd/wstail/matcher.go
@@ -44,14 +44,22 @@ func buildMatcher(filter filter) string {
 		capture = append(capture, file)
 	}
 
-	return matchPrefix + matchWhitespace + strings.Join(capture, "|")
+	// Wrap into brackets to preserve context if file filters are present
+	var suffix string
+	if len(filter.files) > 0 {
+		suffix = "(" + strings.Join(capture, "|") + ")"
+	} else {
+		suffix = strings.Join(capture, "|")
+	}
+
+	return matchPrefix + matchWhitespace + suffix
 }
 
 // Matchers
 const (
-	matchTimestamp       = `[[:digit:]]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[[:digit:]]+Z`
+	matchTimestamp       = `[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+Z`
 	matchWhitespace      = `[[:space:]]+`
-	matchNamePlaceholder = `[a-zA-Z\0-9-]+`
+	matchNamePlaceholder = `[a-zA-Z0-9-]+`
 	matchPlaceholder     = `[^_]+`
 )
 

--- a/cmd/wstail/matcher_test.go
+++ b/cmd/wstail/matcher_test.go
@@ -29,7 +29,7 @@ func (s *S) TestBuildsMatcher(c *C) {
 			filter: filter{
 				files: []string{"foo-bar.log"},
 			},
-			expected: matchPrefix + matchWhitespace + `([^_]+_[^_]+_([a-zA-Z\0-9-]+-foo-bar.log))|foo-bar.log`,
+			expected: matchPrefix + matchWhitespace + `(([^_]+_[^_]+_([a-zA-Z0-9-]+-foo-bar.log))|foo-bar.log)`,
 			comment:  "matches a file either in pod/container context or alone",
 		},
 	}

--- a/cmd/wstail/tail.go
+++ b/cmd/wstail/tail.go
@@ -72,9 +72,7 @@ func tailer(ws *websocket.Conn, filter filter) {
 		if err != nil {
 			log.Warningf("failed to obtain history for %v: %v", matcher, trace.DebugReport(err))
 		}
-		// --line-buffered is not supported in busybox
-		// grepCmd := exec.Command("grep", "--line-buffered", "-E", matcher)
-		grepCmd := exec.Command("grep", "-E", matcher)
+		grepCmd := exec.Command("grep", "--line-buffered", "-E", matcher)
 		commands = append(commands, grepCmd)
 	}
 	pipe, err := pipeCommands(commands...)
@@ -220,7 +218,7 @@ func snapshot(matcher string, rotated rotatedLogs, tailLimit int) (io.ReadCloser
 	if len(rotated.Compressed) == 0 {
 		return nil, nil
 	}
-	args := append([]string{"-E", matcher}, rotated.Compressed...)
+	args := append([]string{"--line-buffered", "--no-filename", "-E", matcher}, rotated.Compressed...)
 	log.Infof("requesting history for %v", matcher)
 	commands := []*exec.Cmd{exec.Command("zgrep", args...)}
 	if tailLimit > 0 {

--- a/resources/resources.yaml
+++ b/resources/resources.yaml
@@ -94,6 +94,8 @@ spec:
               mountPath: /var/log/containers
             - name: extdockercontainers
               mountPath: /ext/docker/containers
+            - name: gravitysite
+              mountPath: /var/lib/gravity/site
       volumes:
         - name: gravitylog
           hostPath:
@@ -104,3 +106,6 @@ spec:
         - name: extdockercontainers
           hostPath:
             path: /ext/docker/containers
+        - name: gravitysite
+          hostPath:
+            path: /var/lib/gravity/site


### PR DESCRIPTION
- open `/var/lib/gravity/site` in forwarder to support tailing expand/shrink/update operation logs
- limit the history length also to `tailMaxDepth` if displaying history with an empty filter
- preserve match context for file filters to avoid including unrelated detail in logs
- unify match syntax for digits to `[0-9]` (as opposed to `[:digit:]`) as `grep` in collector container supports it
