### PR TITLE
Do no reopen delete log files in a loop - backport 1.x

### DIFF
--- a/images/forwarder/Dockerfile
+++ b/images/forwarder/Dockerfile
@@ -7,4 +7,4 @@ RUN chmod +x /usr/local/bin/remote_syslog
 
 RUN test -f /cleanup.sh && sh /cleanup.sh
 
-ENTRYPOINT ["/usr/local/bin/remote_syslog", "--poll", "-D", "-c", "/etc/remote_syslog.yml"]
+ENTRYPOINT ["/usr/local/bin/remote_syslog", "--poll", "-D", "--reopen=false", "-c", "/etc/remote_syslog.yml"]

--- a/images/forwarder/Makefile
+++ b/images/forwarder/Makefile
@@ -1,7 +1,4 @@
-# We need a version >v0.18 as it contains
-# https://github.com/papertrail/remote_syslog2/pull/174
-# in which remote_syslog2 forwards new files entirely
-override VERSION:=415704611b83856f20431fa495144a011651b6a6
+override VERSION:=dmitri/polling
 GOFLAGS=-installsuffix cgo --ldflags '-w -s' -a
 GOBUILDPREFIX=GOOS=linux GOARCH=amd64 CGO_ENABLED=0
 BASEREPO:=github.com/gravitational

--- a/images/forwarder/Makefile
+++ b/images/forwarder/Makefile
@@ -1,4 +1,4 @@
-override VERSION:=dmitri/polling
+override VERSION:=f55ba1b5cae7aaf36416f65ce0f1b461a1f4b95e
 GOFLAGS=-installsuffix cgo --ldflags '-w -s' -a
 GOBUILDPREFIX=GOOS=linux GOARCH=amd64 CGO_ENABLED=0
 BASEREPO:=github.com/gravitational


### PR DESCRIPTION
Switch to polling branch on the updated remote_syslog2 to fix the problem with poller retaining open log files history forever and interfering with [docker cleaning up container filesystems](https://github.com/gravitational/gravity/issues/1815)

Fixes https://github.com/gravitational/gravity/issues/1815