### PR TITLE
Mount `/var/log/` in forwarders

### DIFF
--- a/images/hook/Dockerfile
+++ b/images/hook/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/gravitational/rig:0.0.1
+FROM quay.io/gravitational/rig:0.0.5
 
 ARG CHANGESET
 ENV RIG_CHANGESET $CHANGESET

--- a/images/hook/entrypoint.sh
+++ b/images/hook/entrypoint.sh
@@ -10,8 +10,9 @@ if [ $1 = "update" ]; then
 
     echo "Starting update, changeset: $RIG_CHANGESET"
     rig cs delete --force -c cs/$RIG_CHANGESET
-    echo "Deleting old replication controller rc/log-forwarder"
-    rig delete rc/log-collector --resource-namespace=kube-system --force
+    echo "Deleting old deployments/daemonsets"
+    rig delete deployments/log-collector --resource-namespace=kube-system --force
+    rig delete daemonsets/log-forwarder --resource-namespace=kube-system --force
     echo "Creating or updating resources"
     rig upsert -f /var/lib/gravity/resources/resources.yaml --debug
     echo "Checking status"

--- a/resources/resources.yaml
+++ b/resources/resources.yaml
@@ -97,21 +97,16 @@ spec:
         - name: log-forwarder
           image: log-forwarder:latest
           volumeMounts:
-            - name: gravitylog
-              mountPath: /var/log/gravity
-            - name: varlogcontainers
-              mountPath: /var/log/containers
+            - name: varlog
+              mountPath: /var/log
             - name: extdockercontainers
               mountPath: /ext/docker/containers
             - name: gravitysite
               mountPath: /var/lib/gravity/site
       volumes:
-        - name: gravitylog
+        - name: varlog
           hostPath:
-            path: /var/log/gravity
-        - name: varlogcontainers
-          hostPath:
-            path: /var/log/containers
+            path: /var/log
         - name: extdockercontainers
           hostPath:
             path: /ext/docker/containers


### PR DESCRIPTION
Loosen the mounts to /var/log to avoid issues with symlinks in k8s 1.7: log files in `/var/log/containers` now link to `/var/log/pods` and the forwarder is not able to read/forward them.

Updates https://github.com/gravitational/gravity/issues/2460