### PR TITLE
Add security context to log pods

### DIFF
--- a/resources/resources.yaml
+++ b/resources/resources.yaml
@@ -50,6 +50,8 @@ spec:
       annotations:
         seccomp.security.alpha.kubernetes.io/pod: docker/default
     spec:
+      securityContext:
+        runAsUser: 0
       containers:
         - name: log-collector
           image: log-collector:latest
@@ -89,6 +91,8 @@ spec:
       annotations:
         seccomp.security.alpha.kubernetes.io/pod: docker/default
     spec:
+      securityContext:
+        runAsUser: 0
       containers:
         - name: log-forwarder
           image: log-forwarder:latest


### PR DESCRIPTION
Without it forwarder/collector are run as 2000 and nothing works.