### PR TITLE
Remove 32 character default length limit for syslog tags.

### DIFF
--- a/cmd/wstail/main.go
+++ b/cmd/wstail/main.go
@@ -14,13 +14,19 @@ import (
 
 func main() {
 	log.SetLevel(log.InfoLevel)
+	log.SetOutput(os.Stderr)
 
 	var filePath string
 	var httpAddr = flag.String("addr", ":8083", "HTTP service address")
+	var debug = flag.Bool("debug", false, "Verbose mode")
 	var initForwarders = flag.Bool("init-forwarders", false,
 		"Initialize log forwarders and exit")
 
 	flag.Parse()
+
+	if *debug {
+		log.SetLevel(log.DebugLevel)
+	}
 
 	if *initForwarders {
 		err := initLogForwarders()

--- a/images/collector/entrypoint.sh
+++ b/images/collector/entrypoint.sh
@@ -6,5 +6,12 @@ if [ "$tail_port" = ":" ]; then
 	tail_port=:8083
 fi
 
+opts=
+if [ "x$DEBUG" != "x" ]; then
+  export RSYSLOG_DEBUG=Debug
+  export RSYSLOG_DEBUGLOG=/var/log/rsyslog.log
+  opts=-debug
+fi
+
 /usr/sbin/rsyslogd
-/wstail -addr=$tail_port
+/wstail -addr=$tail_port $opts

--- a/images/collector/rsyslog.conf
+++ b/images/collector/rsyslog.conf
@@ -20,4 +20,8 @@ input(type="imtcp" port="5514")
 module(load="imudp")
 input(type="imudp" port="5514")
 
+# Remove the 32 characters syslog tag length default
+# to capture full resource path
+template (name="LongTagForwardFormat" type="string" string="<%PRI%>%TIMESTAMP:::date-rfc3339% %HOSTNAME% %syslogtag%%msg:::sp-if-no-1st-sp%%msg%")
+
 $IncludeConfig /etc/rsyslog.d/


### PR DESCRIPTION
 - Add a verbose flag and make it overridable via a DEBUG environment variable.
 - Use expressive configuration format to be able to specify the formatting template to use for forwarder.

Fixes https://github.com/gravitational/gravity/issues/3106.