### PR TITLE
Update rigging to upcoming 0.0.10.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,11 @@ OPS_URL ?= https://opscenter.localhost.localdomain:33009
 OUT ?= $(NAME).tar.gz
 GRAVITY ?= gravity
 UPDATE_IMAGE_OPTS := \
-	--set-image=log-collector:$(VERSION) --set-image=log-forwarder:$(VERSION) \
-	--set-image=log-tailer:$(VERSION) --set-image=log-linker:$(VERSION) --set-image=log-hook:$(VERSION)
+	--set-image=log-collector:$(VERSION) \
+	--set-image=log-forwarder:$(VERSION) \
+	--set-image=log-tailer:$(VERSION) \
+	--set-image=log-linker:$(VERSION) \
+	--set-image=log-hook:$(VERSION)
 UPDATE_METADATA_OPTS := --repository=$(REPOSITORY) --name=$(NAME) --version=$(VERSION)
 
 .PHONY: package
@@ -31,13 +34,22 @@ deploy:
 
 .PHONY: import
 import: package
-	-$(GRAVITY) app delete --ops-url=$(OPS_URL) $(REPOSITORY)/$(NAME):$(VERSION) \
+	-$(GRAVITY) app delete \
+		--ops-url=$(OPS_URL) \
+		$(REPOSITORY)/$(NAME):$(VERSION) \
 		--force --insecure
 	$(GRAVITY) app import --insecure --vendor \
 		--ops-url=$(OPS_URL) \
 		$(UPDATE_IMAGE_OPTS) \
 		$(UPDATE_METADATA_OPTS) \
 		--include=resources --include=registry .
+
+.PHONY: tarball
+tarball: import
+	$(GRAVITY) package export \
+		--ops-url=$(OPS_URL) \
+		$(REPOSITORY)/$(NAME):$(VERSION) \
+		$(NAME)-$(VERSION).tar.gz
 
 .PHONY: clean
 clean:

--- a/images/buildbox.mk
+++ b/images/buildbox.mk
@@ -17,7 +17,7 @@ override BUILDDIR=$(ASSETS)/build
 # Configuration by convention: use TARGET as a directory name
 BINARIES=$(BUILDDIR)/$(TARGET)
 
-BBOX := quay.io/gravitational/debian-venti:go1.7.1-jessie
+BBOX := quay.io/gravitational/debian-venti:go1.9-stretch
 
 all: prepare $(BINARIES)
 

--- a/images/hook/Dockerfile
+++ b/images/hook/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/gravitational/rig:0.0.9
+FROM quay.io/gravitational/rig:0.0.10
 
 ARG CHANGESET
 ENV RIG_CHANGESET $CHANGESET


### PR DESCRIPTION
Update buildbox to build with go1.9.

Requires https://github.com/gravitational/rigging/pull/44