### PR TITLE
Set requests/limits on logrange components

### DIFF
--- a/resources/app/log-collector.yaml
+++ b/resources/app/log-collector.yaml
@@ -132,6 +132,13 @@ spec:
               mountPath: /var/log
             - name: varstate
               mountPath: /var/state
+          resources:
+            requests:
+              memory: 100Mi
+              cpu: 100m
+            limits:
+              memory: 500Mi
+              cpu: 500m
       volumes:
         - name: config
           configMap:

--- a/resources/app/lr-aggregator.yaml
+++ b/resources/app/lr-aggregator.yaml
@@ -104,6 +104,13 @@ spec:
               mountPath: /var/log
             - name: varstate
               mountPath: /var/state
+          resources:
+            requests:
+              memory: 100Mi
+              cpu: 100m
+            limits:
+              memory: 500Mi
+              cpu: 500m
       volumes:
         - name: config
           configMap:
@@ -121,7 +128,6 @@ spec:
         - name: varstate
           hostPath:
             path: /var/state
-
       affinity:
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/resources/app/lr-collector.yaml
+++ b/resources/app/lr-collector.yaml
@@ -101,6 +101,13 @@ spec:
               mountPath: /var/log
             - name: varstate
               mountPath: /var/state
+          resources:
+            requests:
+              memory: 100Mi
+              cpu: 100m
+            limits:
+              memory: 500Mi
+              cpu: 500m
       volumes:
         - name: config
           configMap:

--- a/resources/app/lr-forwarder.yaml
+++ b/resources/app/lr-forwarder.yaml
@@ -71,6 +71,13 @@ spec:
               mountPath: /var/log
             - name: varstate
               mountPath: /var/state
+          resources:
+            requests:
+              memory: 100Mi
+              cpu: 100m
+            limits:
+              memory: 500Mi
+              cpu: 500m
       volumes:
         - name: config
           configMap:


### PR DESCRIPTION
It's been reported that logrange (specifically, the aggregator) on some clusters consumes a lot of CPU/memory over time (https://github.com/gravitational/gravity/issues/1241).

I've noticed we do not set requests and limits on the logrange components, so this PR sets them. To pick the limits I've looked at the historical data in some of my existing long-running clusters and logrange CPU/memory usage stays stable there (around 1-2% CPU and no more than a 100MB of memory) so I picked something conservative to accommodate potential spikes.
