### PR TITLE
Increase logs size and number of stored files

### DIFF
--- a/images/collector/log_rotation_script
+++ b/images/collector/log_rotation_script
@@ -1,3 +1,4 @@
 #!/bin/sh
 
-/usr/bin/savelog -n -c 7 /var/log/messages
+# set cycle versions to 9 to have at least 10 files with logs
+/usr/bin/savelog -n -c 9 /var/log/messages

--- a/images/collector/rsyslog.conf
+++ b/images/collector/rsyslog.conf
@@ -8,7 +8,8 @@ $FileCreateMode 0640
 $DirCreateMode 0755
 $Umask 0022
 
-$outchannel log_rotation,/var/log/messages, 52428800, /root/log_rotation_script
+# set log file size to 256MB
+$outchannel log_rotation,/var/log/messages, 268435456, /root/log_rotation_script
 *.* :omfile:$log_rotation
 
 # ######### Receiving Messages from Remote Hosts ##########


### PR DESCRIPTION
Increase log file size and number of stored logs after recycling them. This would help to have at least one day of logs on the cluster with hundreds of working pods. This is helpful for debugging failed upgrades especially when logs from the upgrade could be rotated in a few hours after fail.
As a downside, the change will increase disk usage from ~150-170MB to 700-800MB, which is not critical I assume. 