### PR TITLE
[5.5] fix remote syslog goroutine leak

### DIFF
--- a/images/forwarder/Dockerfile
+++ b/images/forwarder/Dockerfile
@@ -7,4 +7,4 @@ RUN chmod +x /usr/local/bin/remote_syslog
 
 RUN test -f /cleanup.sh && sh /cleanup.sh
 
-ENTRYPOINT ["/usr/local/bin/remote_syslog", "--poll", "-D", "--reopen=false", "-c", "/etc/remote_syslog.yml"]
+ENTRYPOINT ["/usr/local/bin/remote_syslog", "--poll", "-D", "--reopen=true", "-c", "/etc/remote_syslog.yml"]

--- a/images/forwarder/Makefile
+++ b/images/forwarder/Makefile
@@ -1,4 +1,4 @@
-override VERSION:=f55ba1b5cae7aaf36416f65ce0f1b461a1f4b95e
+override VERSION:=b75c3263436114d5d8decccd2d59e83657bac29e
 GOFLAGS=-installsuffix cgo --ldflags '-w -s' -a
 GOBUILDPREFIX=GOOS=linux GOARCH=amd64 CGO_ENABLED=0
 BASEREPO:=github.com/gravitational


### PR DESCRIPTION
This PR fixes an issue with remote_syslog leaking CPU time as a cluster operates normally. 

1. Integrates upstream fixes to eliminate leaked goroutines hung attempting to monitor deleted files.
2. Re-enables attempting to re-open deleted files, which triggers the unneeded goroutines to exit and the resources to be reclaimed.

This change has a side effect of remote_syslog producing the following log message which was likely not present previously: `2020-09-01 04:25:47 ERROR  remote_syslog.go:120 open /var/log/containers/hello4-1598934120-ldkhk_default_hello-cda3a107970ae2b10ace52b1a62ae50091e0914723ea74605072302e60df40b4.log: no such file or directory`
I don't believe the additional logging is a concern.

On my test cluster using the steps to reproduce, I no longer see linear increases to CPU usage by remote_syslog as the cluster operates. 

Updates: https://github.com/gravitational/gravity/issues/2069