### PR TITLE
[5.5] ensure logging-app resources tolerate any taint

### DIFF
--- a/resources/resources.yaml
+++ b/resources/resources.yaml
@@ -46,13 +46,8 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       tolerations:
-        - key: "gravitational.io/runlevel"
-          value: system
-          operator: Equal
-        # allows to run on master nodes
-        - key: "node-role.kubernetes.io/master"
-          operator: "Exists"
-          effect: "NoSchedule"
+      # tolerate any taints
+      - operator: "Exists"
       securityContext:
         runAsUser: 0
       initContainers:
@@ -112,13 +107,8 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       tolerations:
-        - key: "gravitational.io/runlevel"
-          value: system
-          operator: Equal
-        # allows to run on master nodes
-        - key: "node-role.kubernetes.io/master"
-          operator: "Exists"
-          effect: "NoSchedule"
+      # tolerate any taints
+      - operator: "Exists"
       securityContext:
         runAsUser: 0
       containers:


### PR DESCRIPTION
Updates https://github.com/gravitational/gravity/issues/2281

Customers can set any taint with an application manifest, so gravitational components sort of need to support any taint in order to run. This isn't a great solution, since we probably want to follow the builtin kubernetes health related taints. For now, support any taint so that customer applied taints don't block the builtins from functioning.