### PR TITLE
[master] ensure logrange resources tolerate any taint

### DIFF
--- a/resources/app/log-collector.yaml
+++ b/resources/app/log-collector.yaml
@@ -108,6 +108,9 @@ spec:
           type: gravity_container_logger_t
       nodeSelector:
         gravitational.io/k8s-role: master
+      tolerations:
+      # tolerate any taints
+      - operator: "Exists"
       containers:
         - name: log-collector
           image: log-adapter:0.1.0

--- a/resources/app/lr-aggregator.yaml
+++ b/resources/app/lr-aggregator.yaml
@@ -86,6 +86,9 @@ spec:
           type: gravity_container_logger_t
       nodeSelector:
         gravitational.io/k8s-role: master
+      tolerations:
+      # tolerate any taints
+      - operator: "Exists"
       containers:
         - name: lr-aggregator
           image: "index.docker.io/logrange/logrange:v0.0.0"

--- a/resources/app/lr-collector.yaml
+++ b/resources/app/lr-collector.yaml
@@ -85,6 +85,9 @@ spec:
         runAsUser: 0
         seLinuxOptions:
           type: gravity_container_logger_t
+      tolerations:
+      # tolerate any taints
+      - operator: "Exists"
       containers:
         - name: lr-collector
           image: "index.docker.io/logrange/collector:v0.0.0"

--- a/resources/app/lr-forwarder.yaml
+++ b/resources/app/lr-forwarder.yaml
@@ -57,6 +57,9 @@ spec:
           type: gravity_container_logger_t
       nodeSelector:
         gravitational.io/k8s-role: master
+      tolerations:
+      # tolerate any taints
+      - operator: "Exists"
       containers:
         - name: lr-forwarder
           image: "index.docker.io/logrange/forwarder:v0.0.0"


### PR DESCRIPTION
Updates https://github.com/gravitational/gravity/issues/2281

Customers can set any taint with an application manifest, so gravitational components sort of need to support any taint in order to run. This isn't a great solution, since we probably want to follow the builtin kubernetes health related taints. For now, support any taint so that customer applied taints don't block the builtins from functioning.