### PR TITLE
[7.0.x] Fix panic in parseCSVIntoMap

### DIFF
--- a/cmd/adapter/api/api.go
+++ b/cmd/adapter/api/api.go
@@ -369,6 +369,7 @@ func toGravityLogEntries(evs []*api.LogEvent) ([]string, error) {
 // with each element in the form `key=value` and translates it into a "dictionary" map
 func parseCSVIntoMap(csv string) (results map[string]string) {
 
+	results = make(map[string]string)
 	// iterate over the elements in the form `elem1, elem2, elem3, ...`
 	for _, elem := range strings.Split(csv, ",") {
 


### PR DESCRIPTION
Fixes panic when calling log api `curl http://log-collector.kube-system.svc.cluster.local:8083/v1/log`.

``` shell
time="2021-03-29T18:42:57Z" level=info msg="log(): Query=SELECT FROM logrange.pipe=__default__ OFFSET -1000 LIMIT 1000" trace.component=logging-app.api
2021/03/29 18:42:57 http: panic serving 100.96.102.1:1722: assignment to entry in nil map
goroutine 343 [running]:
net/http.(*conn).serve.func1(0xc0001d2280)
        /go/src/net/http/server.go:1769 +0x139
panic(0x117e360, 0x1457ab0)
        /go/src/runtime/panic.go:522 +0x1b5
github.com/gravitational/logging-app/cmd/adapter/api.parseCSVIntoMap(0xc0001fe2a0, 0x19, 0x3e8)
        /gopath/src/github.com/gravitational/logging-app/cmd/adapter/api/api.go:380 +0x1ad
github.com/gravitational/logging-app/cmd/adapter/api.toGravityLogEntries(0xc00048e000, 0x3e8, 0x3e8, 0xc00036c680, 0xc0000fe070, 0x0, 0x0, 0x3d)
        /gopath/src/github.com/gravitational/logging-app/cmd/adapter/api/api.go:355 +0x131
github.com/gravitational/logging-app/cmd/adapter/api.(*Server).logHandler(0xc00025c720, 0x1498b00, 0xc0001ece40, 0x1484840, 0xc00024e260, 0xc000290500, 0x0, 0x0, 0x0, 0x0, ...)
        /gopath/src/github.com/gravitational/logging-app/cmd/adapter/api/api.go:184 +0x358
github.com/gravitational/logging-app/cmd/adapter/api.(*Server).makeHandlerWithCtx.func1(0x1490680, 0xc00023a000, 0xc000290500, 0x0, 0x0, 0x0)
        /gopath/src/github.com/gravitational/logging-app/cmd/adapter/api/api.go:290 +0xf9
github.com/gravitational/logging-app/vendor/github.com/julienschmidt/httprouter.(*Router).ServeHTTP(0xc0001ece80, 0x1490680, 0xc00023a000, 0xc000290500)
        /gopath/src/github.com/gravitational/logging-app/vendor/github.com/julienschmidt/httprouter/router.go:334 +0x948
net/http.serverHandler.ServeHTTP(0xc000494340, 0x1490680, 0xc00023a000, 0xc000290500)
        /go/src/net/http/server.go:2774 +0xa8
net/http.(*conn).serve(0xc0001d2280, 0x1498b00, 0xc00036c480)
        /go/src/net/http/server.go:1878 +0x851
created by net/http.(*Server).Serve
        /go/src/net/http/server.go:2884 +0x2f4
```