### PR TITLE
Run containers with normal users

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ package:
 	$(MAKE) -C images all
 
 .PHONY: adapter
-collector:
+adapter:
 	$(MAKE) -C images adapter
 
 .PHONY: hook

--- a/images/adapter/Dockerfile
+++ b/images/adapter/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/gravitational/debian-tall:stretch
+FROM quay.io/gravitational/debian-tall:buster
 
 RUN mkdir -p /opt/logrange/gravity
 

--- a/images/buildbox.mk
+++ b/images/buildbox.mk
@@ -17,7 +17,7 @@ override BUILDDIR=$(ASSETS)/build
 # Configuration by convention: use TARGET as a directory name
 BINARIES=$(BUILDDIR)/$(TARGET)
 
-BBOX := quay.io/gravitational/debian-venti:go1.12.9-buster
+BBOX := quay.io/gravitational/debian-venti:go1.15.10-buster
 LAPP := github.com/gravitational/logging-app
 
 all: prepare $(BINARIES)

--- a/images/hook/entrypoint.sh
+++ b/images/hook/entrypoint.sh
@@ -14,8 +14,10 @@ if [ $1 = "install" ]; then
     kubectl create -f /var/lib/gravity/resources/app
 
     echo "--> Waiting resources availability"
-    set +e # debug error here
-    kubectl rollout status -f /var/lib/gravity/resources/app
+    for deployment in log-collector lr-forwarder lr-aggregator; do
+	kubectl rollout status deployment $deployment
+    done
+    kubectl rollout status daemonset lr-collector
 elif [ $1 = "update" ]; then
     echo "--> Deleting old deployments"
     for deployment in log-collector lr-forwarder lr-aggregator; do

--- a/images/hook/entrypoint.sh
+++ b/images/hook/entrypoint.sh
@@ -14,6 +14,7 @@ if [ $1 = "install" ]; then
     kubectl create -f /var/lib/gravity/resources/app
 
     echo "--> Waiting resources availability"
+    set +e # debug error here
     kubectl rollout status -f /var/lib/gravity/resources/app
 elif [ $1 = "update" ]; then
     echo "--> Deleting old deployments"

--- a/images/hook/entrypoint.sh
+++ b/images/hook/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -e
+set -xe
 
 # note that rig does not take explicit changeset ID
 # taking it from the environment variables
@@ -7,19 +7,14 @@ set -e
 echo "--> Assuming changeset from the environment: $RIG_CHANGESET"
 if [ $1 = "install" ]; then
     echo "--> Creating Log Forwarder ConfigMap"
-    kubectl apply -f /var/lib/gravity/resources/logforwarder.yaml
+    kubectl create -f /var/lib/gravity/resources/logforwarder.yaml
 
     echo "--> Creating new Log Forwarder related resources"
-    for file in /var/lib/gravity/resources/app/*.yaml; do
-        kubectl apply -f $file
-    done
+    kubectl create -f /var/lib/gravity/resources/app
+
+    echo "--> Waiting resources availability"
+    kubectl rollout status -f /var/lib/gravity/resources/app
 elif [ $1 = "update" ]; then
-    echo "--> Checking: $RIG_CHANGESET"
-    if rig status ${RIG_CHANGESET} --retry-attempts=1 --retry-period=1s; then exit 0; fi
-
-    echo "--> Starting update, changeset: $RIG_CHANGESET"
-    rig cs delete --force -c cs/${RIG_CHANGESET}
-
     echo "--> Deleting old deployments"
     for deployment in log-collector lr-forwarder lr-aggregator; do
         rig delete deployments/$deployment --resource-namespace=kube-system --force

--- a/images/hook/entrypoint.sh
+++ b/images/hook/entrypoint.sh
@@ -7,7 +7,8 @@ set -xe
 echo "--> Assuming changeset from the environment: $RIG_CHANGESET"
 if [ $1 = "install" ]; then
     echo "--> Creating Log Forwarder ConfigMap"
-    kubectl create -f /var/lib/gravity/resources/logforwarder.yaml
+    # apply is used here because log-forwarder could be created by gravity
+    kubectl apply -f /var/lib/gravity/resources/logforwarder.yaml
 
     echo "--> Creating new Log Forwarder related resources"
     kubectl create -f /var/lib/gravity/resources/app

--- a/resources/app/log-collector.yaml
+++ b/resources/app/log-collector.yaml
@@ -82,7 +82,7 @@ data:
     }
 
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: log-collector
@@ -103,7 +103,7 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       securityContext:
-        runAsUser: 0
+        runAsUser: -1
         seLinuxOptions:
           type: gravity_container_logger_t
       nodeSelector:
@@ -122,10 +122,6 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/logrange/gravity/config
-            - name: extdockercontainers
-              mountPath: /ext/docker/containers
-            - name: varlog
-              mountPath: /var/log
             - name: varstate
               mountPath: /var/state
           resources:
@@ -139,12 +135,6 @@ spec:
         - name: config
           configMap:
             name: log-collector
-        - name: extdockercontainers
-          hostPath:
-            path: /ext/docker/containers
-        - name: varlog
-          hostPath:
-            path: /var/log
         - name: varstate
           hostPath:
             path: /var/state

--- a/resources/app/lr-aggregator.yaml
+++ b/resources/app/lr-aggregator.yaml
@@ -60,7 +60,7 @@ data:
   log4g.properties: |
     # log4g configuration`
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: lr-aggregator
@@ -81,7 +81,7 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       securityContext:
-        runAsUser: 0
+        runAsUser: -1
         seLinuxOptions:
           type: gravity_container_logger_t
       nodeSelector:
@@ -100,12 +100,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/logrange/config
-            - name: extdockercontainers
-              mountPath: /ext/docker/containers
             - name: varlibgravitylogrange
               mountPath: /var/lib/gravity/logrange
-            - name: varlog
-              mountPath: /var/log
             - name: varstate
               mountPath: /var/state
           resources:
@@ -119,16 +115,10 @@ spec:
         - name: config
           configMap:
             name: lr-aggregator
-        - name: extdockercontainers
-          hostPath:
-            path: /ext/docker/containers
         - name: varlibgravitylogrange
           hostPath:
             path: /var/lib/gravity/logrange
             type: DirectoryOrCreate
-        - name: varlog
-          hostPath:
-            path: /var/log
         - name: varstate
           hostPath:
             path: /var/state

--- a/resources/app/lr-aggregator.yaml
+++ b/resources/app/lr-aggregator.yaml
@@ -26,7 +26,7 @@ metadata:
 data:
   logrange.json: |
     {
-      "BaseDir": "/var/lib/gravity/logrange/data/",
+      "BaseDir": "/var/lib/gravity/logrange/aggregator/",
       "HostHostId": 0,
       "HostLeaseTTLSec": 5,
       "HostRegisterTimeoutSec": 0,

--- a/resources/app/lr-collector.yaml
+++ b/resources/app/lr-collector.yaml
@@ -62,7 +62,7 @@ data:
   log4g.properties: |
     # log4g configuration
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: lr-collector

--- a/resources/app/lr-collector.yaml
+++ b/resources/app/lr-collector.yaml
@@ -56,7 +56,7 @@ data:
       },
       "Storage": {
         "Type": "file",
-        "Location": "/var/lib/gravity/logrange/lr/storage/"
+        "Location": "/var/lib/gravity/logrange/collector/"
       }
     }
   log4g.properties: |

--- a/resources/app/lr-forwarder.yaml
+++ b/resources/app/lr-forwarder.yaml
@@ -25,7 +25,7 @@ data:
 
       "Storage": {
         "Type": "file",
-        "Location": "/var/lib/gravity/logrange/lr/storage/"
+        "Location": "/var/lib/gravity/logrange/forwarder/"
       }
     }
   log4g.properties: |

--- a/resources/app/lr-forwarder.yaml
+++ b/resources/app/lr-forwarder.yaml
@@ -31,7 +31,7 @@ data:
   log4g.properties: |
     # log4g configuration
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: lr-forwarder
@@ -52,7 +52,7 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       securityContext:
-        runAsUser: 0
+        runAsUser: -1
         seLinuxOptions:
           type: gravity_container_logger_t
       nodeSelector:
@@ -67,12 +67,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/logrange/lr/config
-            - name: extdockercontainers
-              mountPath: /ext/docker/containers
             - name: varlibgravitylogrange
               mountPath: /var/lib/gravity/logrange
-            - name: varlog
-              mountPath: /var/log
             - name: varstate
               mountPath: /var/state
           resources:
@@ -86,16 +82,10 @@ spec:
         - name: config
           configMap:
             name: lr-forwarder
-        - name: extdockercontainers
-          hostPath:
-            path: /ext/docker/containers
         - name: varlibgravitylogrange
           hostPath:
             path: /var/lib/gravity/logrange
             type: DirectoryOrCreate
-        - name: varlog
-          hostPath:
-            path: /var/log
         - name: varstate
           hostPath:
             path: /var/state


### PR DESCRIPTION
* `kubectl rollout status` is added to control the rollout of resources. In prior versions, we just spun up resources without checking errors from them.
* Bump docker source images to newer versions.
* Delete unused volume mounts.
* Configure each component to write on disk into its own directory. They don't interact with each other data, but writing into one `/var/lib/gravity/logrange/lr` causes issues with permissions as `lr-collector` still needs to be run with root to read docker logs.

### Testing done:
- [x] Manual installation with checking all the pods are running
```
log-collector-dddc6d596-rp7d6                1/1     Running     2          43m
logging-app-install-2a65b0-jp5vg             0/1     Completed   0          43m
lr-aggregator-55688457b-j7w5m                1/1     Running     0          43m
lr-collector-9ctdz                           1/1     Running     0          43m
lr-collector-g542k                           1/1     Running     0          43m
lr-collector-psczn                           1/1     Running     0          43m
lr-forwarder-7d848c8545-q9xhp                1/1     Running     0          43m
```