### PR TITLE
run as root on 6.1.x

### DIFF
--- a/resources/app/log-collector.yaml
+++ b/resources/app/log-collector.yaml
@@ -103,7 +103,7 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       securityContext:
-        runAsUser: -1
+        runAsUser: 0
         seLinuxOptions:
           type: gravity_container_logger_t
       nodeSelector:

--- a/resources/app/lr-aggregator.yaml
+++ b/resources/app/lr-aggregator.yaml
@@ -81,7 +81,7 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       securityContext:
-        runAsUser: -1
+        runAsUser: 0
         seLinuxOptions:
           type: gravity_container_logger_t
       nodeSelector:

--- a/resources/app/lr-forwarder.yaml
+++ b/resources/app/lr-forwarder.yaml
@@ -52,7 +52,7 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       securityContext:
-        runAsUser: -1
+        runAsUser: 0
         seLinuxOptions:
           type: gravity_container_logger_t
       nodeSelector:


### PR DESCRIPTION
The kubernetes / gravity version on 6.1.x doesn't properly update filesystem permissions, so continue to use root uid on 6.1.x gravity. Partially reverting 04d0875917adc7722d4d90ba2a33a70aeb7d3d1e