### PR TITLE
backout directory changes from 04d0875917adc7722d4d90ba2a33a70aeb7d3d1e

### DIFF
--- a/resources/app/lr-aggregator.yaml
+++ b/resources/app/lr-aggregator.yaml
@@ -26,7 +26,7 @@ metadata:
 data:
   logrange.json: |
     {
-      "BaseDir": "/var/lib/gravity/logrange/aggregator/",
+      "BaseDir": "/var/lib/gravity/logrange/data/",
       "HostHostId": 0,
       "HostLeaseTTLSec": 5,
       "HostRegisterTimeoutSec": 0,

--- a/resources/app/lr-collector.yaml
+++ b/resources/app/lr-collector.yaml
@@ -56,7 +56,7 @@ data:
       },
       "Storage": {
         "Type": "file",
-        "Location": "/var/lib/gravity/logrange/collector/"
+        "Location": "/var/lib/gravity/logrange/lr/storage/"
       }
     }
   log4g.properties: |

--- a/resources/app/lr-forwarder.yaml
+++ b/resources/app/lr-forwarder.yaml
@@ -25,7 +25,7 @@ data:
 
       "Storage": {
         "Type": "file",
-        "Location": "/var/lib/gravity/logrange/forwarder/"
+        "Location": "/var/lib/gravity/logrange/lr/storage/"
       }
     }
   log4g.properties: |


### PR DESCRIPTION
Also backout the directory path changes in 04d0875917adc7722d4d90ba2a33a70aeb7d3d1e as we can't upgrade these paths later in the 7.0 gravity which now expects these new paths to be the UID of planet. So having these new paths breaks upgrades, so maintain the old paths on 6.1.x.